### PR TITLE
Let DirectoryTraverse filter entries based on given predicate

### DIFF
--- a/src/main/java/eu/opertusmundi/common/model/file/FileNamingStrategyContext.java
+++ b/src/main/java/eu/opertusmundi/common/model/file/FileNamingStrategyContext.java
@@ -10,5 +10,16 @@ public abstract class FileNamingStrategyContext {
     }
 
     private final boolean createIfNotExists;
-
+    
+    /**
+     * Validate a name component of a path.
+     * 
+     * @param name a path component
+     * @return
+     */
+    public boolean validateName(String name)
+    {
+        // This is a stub; override in subclasses to provide specific filtering
+        return true;
+    }
 }

--- a/src/main/java/eu/opertusmundi/common/model/file/UserFileNamingStrategyContext.java
+++ b/src/main/java/eu/opertusmundi/common/model/file/UserFileNamingStrategyContext.java
@@ -1,9 +1,18 @@
 package eu.opertusmundi.common.model.file;
 
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
 import lombok.Getter;
 
 public class UserFileNamingStrategyContext extends FileNamingStrategyContext {
 
+    private static final Predicate<String> strictNameMatchPredicate = 
+        Pattern.compile("^[-_a-z0-9]+([.][-_a-z0-9]+)*$", Pattern.CASE_INSENSITIVE).asPredicate();
+    
     protected UserFileNamingStrategyContext(String userName, boolean strict, boolean createIfNotExists) {
         super(createIfNotExists);
 
@@ -27,5 +36,11 @@ public class UserFileNamingStrategyContext extends FileNamingStrategyContext {
 
     public static UserFileNamingStrategyContext of(String userName, boolean strict, boolean createIfNotExists) {
         return new UserFileNamingStrategyContext(userName, strict, createIfNotExists);
+    }
+    
+    @Override
+    public boolean validateName(String name) {
+        Assert.state(!StringUtils.isEmpty(name), "A path component must be non empty");
+        return !strict || strictNameMatchPredicate.test(name); 
     }
 }

--- a/src/main/java/eu/opertusmundi/common/service/DefaultUserFileManager.java
+++ b/src/main/java/eu/opertusmundi/common/service/DefaultUserFileManager.java
@@ -57,13 +57,14 @@ public class DefaultUserFileManager implements UserFileManager {
         try {
             final UserFileNamingStrategyContext ctx = UserFileNamingStrategyContext.of(command.getUserName());
 
+            // Fixme: normally, this should never be needed here (home directory is setup during registration)
             this.initializeFileSystem(ctx);
 
             final Path target = command.getPath().equals("/")
                 ? this.fileNamingStrategy.getDir(ctx)
                 : this.fileNamingStrategy.resolvePath(ctx, command.getPath());
 
-            return this.directoryTraverse.getDirectoryInfo(target);
+            return this.directoryTraverse.getDirectoryInfo(target, ctx::validateName);
         } catch (final Exception ex) {
             logger.error(String.format("Failed to load files. [userName=%s, path=%s]", command.getUserName(), command.getPath()), ex);
 
@@ -111,7 +112,7 @@ public class DefaultUserFileManager implements UserFileManager {
         try  {
             final UserFileNamingStrategyContext ctx         = UserFileNamingStrategyContext.of(command.getUserName());
             final Path                          userDir     = this.fileNamingStrategy.getDir(ctx);
-            final DirectoryDto                  userDirInfo = this.directoryTraverse.getDirectoryInfo(userDir);
+            final DirectoryDto                  userDirInfo = this.directoryTraverse.getDirectoryInfo(userDir, ctx::validateName);
 
             final long size = userDirInfo.getSize();
             if (size + command.getSize() > this.maxUserSpace) {

--- a/src/main/java/eu/opertusmundi/common/service/DefaultUserFileNamingStrategy.java
+++ b/src/main/java/eu/opertusmundi/common/service/DefaultUserFileNamingStrategy.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,10 +17,6 @@ import eu.opertusmundi.common.model.file.UserFileNamingStrategyContext;
 
 @Service
 public class DefaultUserFileNamingStrategy extends AbstractFileNamingStrategy<UserFileNamingStrategyContext> {
-
-    private final Pattern strictPattern = Pattern.compile("^(\\/{0,1}[a-zA-Z_\\-0-9]+)+(\\.[a-zA-Z0-9]+|\\/?)?$");
-
-    private final Pattern lenientPattern = Pattern.compile("^(\\/{0,1}\\.?[a-zA-Z_\\-0-9]+)+(\\.[a-zA-Z0-9]+|\\/?)?$");
 
     @Value("${opertus-mundi.file-system.max-depth:8}")
     private int maxDepth;
@@ -65,16 +59,15 @@ public class DefaultUserFileNamingStrategy extends AbstractFileNamingStrategy<Us
             if (p.length() > this.maxLength) {
                 throw new FileSystemException(
                     FileSystemMessageCode.PATH_MAX_LENGTH,
-                    String.format("Path segment [%s] length exceeds the limit [%d]", p, this.maxLength)
+                    String.format("Path component [%s] length exceeds the limit [%d]", p, this.maxLength)
                 );
             }
-        }
-        final Matcher matcher = (ctx.isStrict() ? this.strictPattern : this.lenientPattern).matcher(path);
-        if (!matcher.matches()) {
-            throw new FileSystemException(
-                FileSystemMessageCode.INVALID_PATH,
-                String.format("Path [%s] is not valid", path)
-            );
+            if (!ctx.validateName(p)) {
+                throw new FileSystemException(
+                    FileSystemMessageCode.INVALID_PATH,
+                    String.format("Path component [%s] is not valid", p)
+                );
+            }
         }
     }
 

--- a/src/main/java/eu/opertusmundi/common/service/DirectoryTraverse.java
+++ b/src/main/java/eu/opertusmundi/common/service/DirectoryTraverse.java
@@ -2,35 +2,36 @@ package eu.opertusmundi.common.service;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.function.Predicate;
 
 import eu.opertusmundi.common.model.file.DirectoryDto;
 
 public interface DirectoryTraverse
 {
     /**
-     * @see {@link DirectoryTraverse#getDirectoryInfo(Path, int)}
+     * @see DirectoryTraverse#getDirectoryInfo(Path, int, Predicate)
      */
     DirectoryDto getDirectoryInfo(Path rootDir) throws IOException;
 
+    /**
+     * @see DirectoryTraverse#getDirectoryInfo(Path, int, Predicate)
+     */
+    DirectoryDto getDirectoryInfo(Path rootDir, int maxDepth) throws IOException;
+
+    /**
+     * @see DirectoryTraverse#getDirectoryInfo(Path, int, Predicate)
+     */
+    DirectoryDto getDirectoryInfo(Path rootDir, Predicate<String> namePredicate) throws IOException;
+    
     /**
      * Traverse directory entries (recursively) and collect detailed information on
      * file-system entries (files and nested directories).
      *
      * @param rootDir The root directory of this traversal
      * @param maxDepth A maximum depth to descend
+     * @param namePredicate A predicate that filters names to be included (directories or files)
      * @throws IOException
      */
-    DirectoryDto getDirectoryInfo(Path rootDir, int maxDepth) throws IOException;
-
-    /**
-     * Traverse directory entries (recursively) and collect detailed information on
-     * file-system entries (files and nested directories).
-     *
-     * @param rootDir The root directory of this traversal
-     * @param exclude List of folder names to exclude
-     * @throws IOException
-     */
-    DirectoryDto getDirectoryInfo(Path rootDir, List<String> exclude) throws IOException;
+    DirectoryDto getDirectoryInfo(Path rootDir, int maxDepth, Predicate<String> namePredicate) throws IOException;
 
 }


### PR DESCRIPTION
The predicate can be specific to the current file-naming context.
(in the case of user directories, naming context filters-out hidden files starting with a dot)  

@jkouvar 
